### PR TITLE
Terminal

### DIFF
--- a/src/File/File.cpp
+++ b/src/File/File.cpp
@@ -25,7 +25,6 @@
 
 #include <cerrno>
 #include <string>
-#include <system_error>
 #include <unistd.h>
 
 namespace Kilo::IO {

--- a/src/File/File.cpp
+++ b/src/File/File.cpp
@@ -38,16 +38,9 @@ namespace Kilo::IO {
  * @throws std::system_error On read failure
  * @returns The number of bytes read
  */
-std::size_t File::read(int fd, std::string& buffer)
+std::size_t File::read(int fd, std::string& buffer) noexcept
 {
-  errno = 0;
-  auto result = ::read(fd, &buffer[0], buffer.length());
-
-  if (result < 0) {
-    throw std::system_error(errno, std::system_category());
-  }
-
-  return result;
+  return ::read(fd, &buffer[0], buffer.length());
 }
 
 /**
@@ -55,19 +48,11 @@ std::size_t File::read(int fd, std::string& buffer)
  *
  * @param fd The file descriptor being written to
  * @param buffer The buffer being written from
- * @throws std::system_error On write failure
  * @returns The number of bytes written
  */
-std::size_t File::write(int fd, std::string const& buffer)
+std::size_t File::write(int fd, std::string const& buffer) noexcept
 {
-  errno = 0;
-  auto result = ::write(fd, buffer.c_str(), buffer.length());
-
-  if (result < 0) {
-    throw std::system_error(errno, std::system_category());
-  }
-
-  return result;
+  return ::write(fd, buffer.c_str(), buffer.length());
 }
 
 }   // namespace Kilo::IO

--- a/src/File/File.cpp
+++ b/src/File/File.cpp
@@ -32,9 +32,8 @@ namespace Kilo::IO {
 /**
  * @brief Read nbytes from fd into buffer
  *
- * @param fd The file being read from
- * @param buffer The buffer being read to
- * @throws std::system_error On read failure
+ * @param[in] fd The file being read from
+ * @param[inout] buffer The buffer being read to
  * @returns The number of bytes read
  */
 std::size_t File::read(int fd, std::string& buffer) noexcept
@@ -45,8 +44,8 @@ std::size_t File::read(int fd, std::string& buffer) noexcept
 /**
  * @brief Write n bytes of buffer to fd
  *
- * @param fd The file descriptor being written to
- * @param buffer The buffer being written from
+ * @param[in] fd The file descriptor being written to
+ * @param[in] buffer The buffer being written from
  * @returns The number of bytes written
  */
 std::size_t File::write(int fd, std::string const& buffer) noexcept

--- a/src/File/File.hpp
+++ b/src/File/File.hpp
@@ -39,7 +39,7 @@ public:
    * @param buffer The buffer being read to
    * @returns The number of bytes read
    */
-  virtual std::size_t read(int fd, std::string& buffer) = 0;
+  virtual std::size_t read(int fd, std::string& buffer) noexcept = 0;
 
   /**
    * @brief Write n bytes of buffer to fd
@@ -48,7 +48,7 @@ public:
    * @param buffer The buffer being written from
    * @returns The number of bytes written
    */
-  virtual std::size_t write(int fd, std::string const& buffer) = 0;
+  virtual std::size_t write(int fd, std::string const& buffer) noexcept = 0;
 
   /**
    * @brief Destructor
@@ -67,20 +67,18 @@ public:
    *
    * @param fd The file being read from
    * @param buffer The buffer being read to
-   * @throws std::system_error On read failure
    * @returns The number of bytes read
    */
-  std::size_t read(int fd, std::string& buffer) override;
+  std::size_t read(int fd, std::string& buffer) noexcept override;
 
   /**
    * @brief Write n bytes of buffer to fd
    *
    * @param fd The file descriptor being written to
    * @param buffer The buffer being written from
-   * @throws std::system_error On write failure
    * @returns The number of bytes written
    */
-  std::size_t write(int fd, std::string const& buffer) override;
+  std::size_t write(int fd, std::string const& buffer) noexcept override;
 };
 
 }   // namespace Kilo::IO

--- a/src/ScreenBuffer/ScreenBuffer.cpp
+++ b/src/ScreenBuffer/ScreenBuffer.cpp
@@ -34,7 +34,7 @@ namespace Kilo::editor {
 /// \param[in] file The file being written to
 /// \returns The number of bytes written
 /// \throws `std::system_error` if the operation failed
-std::size_t ScreenBuffer::flush(IO::File& file) const
+std::size_t ScreenBuffer::flush(IO::FileInterface& file) const
 {
   std::size_t totalWritten = 0;
 

--- a/src/ScreenBuffer/ScreenBuffer.cpp
+++ b/src/ScreenBuffer/ScreenBuffer.cpp
@@ -23,7 +23,9 @@
 
 #include "ScreenBuffer.hpp"
 
+#include <cassert>
 #include <cerrno>
+#include <system_error>
 #include <unistd.h>
 
 namespace Kilo::editor {
@@ -34,7 +36,30 @@ namespace Kilo::editor {
 /// \throws `std::system_error` if the operation failed
 std::size_t ScreenBuffer::flush(IO::File& file) const
 {
-  return file.write(STDOUT_FILENO, m_buffer.c_str());
+  std::size_t totalWritten = 0;
+
+  while (totalWritten < m_buffer.length()) {
+    errno = 0;
+    long result = file.write(STDOUT_FILENO, m_buffer.substr(0 + totalWritten, m_buffer.length() - totalWritten));
+
+    if (result == -1) {
+      if (errno == EINTR or errno == EAGAIN) {
+        continue;
+      }
+      else {
+        throw std::system_error(errno, std::system_category());
+      }
+    }
+
+    if (result == 0) {
+      break;
+    }
+
+    totalWritten += result;
+  }
+
+  assert(totalWritten == m_buffer.length() && "The total number of bytes written is unequal to the size of the buffer");
+  return totalWritten;
 }
 
 }   // namespace Kilo::editor

--- a/src/ScreenBuffer/ScreenBuffer.cpp
+++ b/src/ScreenBuffer/ScreenBuffer.cpp
@@ -58,7 +58,8 @@ std::size_t ScreenBuffer::flush(IO::FileInterface& file) const
     totalWritten += result;
   }
 
-  assert(totalWritten == m_buffer.length() && "The total number of bytes written is unequal to the size of the buffer");
+  assert(totalWritten == m_buffer.length()
+         or totalWritten == 0 && "The total number of bytes written is unequal to the size of the buffer");
   return totalWritten;
 }
 

--- a/src/ScreenBuffer/ScreenBuffer.hpp
+++ b/src/ScreenBuffer/ScreenBuffer.hpp
@@ -78,7 +78,7 @@ public:
   /// \param[in] file The file being written to
   /// \returns The number of bytes written
   /// \throws `std::system_error` if the operation failed
-  std::size_t flush(IO::File& file) const;
+  std::size_t flush(IO::FileInterface& file) const;
 
 private:
   std::string m_buffer;

--- a/src/Terminal/Terminal.cpp
+++ b/src/Terminal/Terminal.cpp
@@ -57,7 +57,7 @@ void getWindowSize(int* const rows, int* const cols)
  * @throws std::system_error if the terminal window size could not be retrieved
  * @returns The size of the terminal window
  */
-WindowSize getWindowSize(::winsize const& winsize)
+WindowSize getWindowSize(::winsize& winsize)
 {
   if (::ioctl(STDOUT_FILENO, TIOCGWINSZ, &winsize) == -1 or winsize.ws_col == 0) {
     if (errno = 0; ::write(STDOUT_FILENO, "\x1b[999c\x1b[999B", 12) != 12) {

--- a/src/Terminal/Terminal.cpp
+++ b/src/Terminal/Terminal.cpp
@@ -60,7 +60,9 @@ void getWindowSize(int* const rows, int* const cols)
 WindowSize getWindowSize(::winsize& winsize)
 {
   if (::ioctl(STDOUT_FILENO, TIOCGWINSZ, &winsize) == -1 or winsize.ws_col == 0) {
-    if (errno = 0; ::write(STDOUT_FILENO, "\x1b[999c\x1b[999B", 12) != 12) {
+    errno = 0;
+
+    if (::write(STDOUT_FILENO, "\x1b[999c\x1b[999B", 12) != 12) {
       throw std::system_error(errno, std::system_category(),
                               "Could not move the cursor to the bottom-right of the screen");
     }
@@ -131,7 +133,9 @@ void getCursorPosition(int* const rows, int* const cols)
 WindowSize getCursorPosition()
 {
   // Get the position of the cursor
-  if (errno = 0; ::write(STDOUT_FILENO, "\x1b[6n", 4) != 4) {
+  errno = 0;
+
+  if (::write(STDOUT_FILENO, "\x1b[6n", 4) != 4) {
     throw std::system_error(errno, std::system_category(), "Could not get cursor position");
   }
 

--- a/src/Terminal/Terminal.hpp
+++ b/src/Terminal/Terminal.hpp
@@ -49,7 +49,7 @@ void getWindowSize(int* const rows, int* const cols);
  * @throws std::system_error if the terminal window size could not be retrieved
  * @returns The size of the terminal window
  */
-WindowSize getWindowSize(::winsize const& winsize);
+WindowSize getWindowSize(::winsize& winsize);
 
 namespace detail {
 

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -58,7 +58,7 @@ TEST(ScreenBufferTest, c_strReturnsACStringRepresentationOfTheContentsOfTheBuffe
   ASSERT_STREQ(buffer.c_str(), str);
 }
 
-class MockFile : public IO::FileInterface
+class MockFileInterface : public IO::FileInterface
 {
 public:
   MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept, override));
@@ -70,7 +70,7 @@ TEST(ScreenBufferTest, flushReturnsTheNumberOfBytesWrittenOnSuccess)
   using namespace ::testing;
 
   ScreenBuffer buffer;
-  MockFile file;
+  MockFileInterface file;
 
   EXPECT_CALL(file, write(_, _)).Times(1).WillOnce(Return(5));
 
@@ -84,7 +84,7 @@ TEST(ScreenBufferTest, flushThrowsAnExceptionOnFailure)
   using namespace ::testing;
 
   ScreenBuffer buffer;
-  MockFile file;
+  MockFileInterface file;
 
   EXPECT_CALL(file, write(_, _)).Times(1).WillOnce(Throw(std::system_error {}));
 

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -73,10 +73,15 @@ TEST(ScreenBufferTest, flushThrowsAnExceptionOnFailure)
 {
   using namespace ::testing;
 
-  ScreenBuffer buffer;
   MockFileInterface file;
+  ScreenBuffer buffer;
+  buffer.write("Non-retryable error example");
 
-  EXPECT_CALL(file, write(_, _)).Times(1).WillOnce(Throw(std::system_error {}));
+  EXPECT_CALL(file, write(STDOUT_FILENO, std::string("Non-retryable error example")))
+    .WillOnce([](int, std::string const&) {
+      errno = EBADF;
+      return -1;
+    });
 
   ASSERT_THROW(buffer.flush(file), std::system_error);
 }

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -69,14 +69,14 @@ TEST(ScreenBufferTest, flushReturnsTheNumberOfBytesWrittenOnSuccess)
 {
   using namespace ::testing;
 
-  ScreenBuffer buffer;
   MockFileInterface file;
+  ScreenBuffer buffer;
+  buffer.write("Hello, world!");
 
-  EXPECT_CALL(file, write(_, _)).Times(1).WillOnce(Return(5));
-
+  EXPECT_CALL(file, write(STDOUT_FILENO, std::string("Hello, world!"))).WillOnce(Return(13));
   auto rv = buffer.flush(file);
 
-  ASSERT_THAT(rv, Eq(5));
+  ASSERT_THAT(rv, Eq(13));
 }
 
 TEST(ScreenBufferTest, flushThrowsAnExceptionOnFailure)

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -35,7 +35,7 @@ namespace Kilo::editor {
 class MockFile : public IO::File
 {
 public:
-  MOCK_METHOD(std::size_t, write, (int, std::string const&));
+  MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept));
 };
 
 class ScreenBufferTest : public ::testing::Test

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -48,16 +48,6 @@ TEST(ScreenBufferTest, ItsSizeIncreasesByTheLengthOfTheAppendedString)
   ASSERT_EQ(buffer.size(), 13);
 }
 
-TEST(ScreenBufferTest, c_strReturnsACStringRepresentationOfTheContentsOfTheBuffer)
-{
-  ScreenBuffer buffer;
-  char const* str = "The quick brown fox jumped over the lazy dog";
-
-  buffer.write(str, std::strlen(str));
-
-  ASSERT_STREQ(buffer.c_str(), str);
-}
-
 class MockFileInterface : public IO::FileInterface
 {
 public:

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -36,6 +36,7 @@ class MockFile : public IO::File
 {
 public:
   MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept));
+  MOCK_METHOD(std::size_t, read, (int, std::string&), (noexcept, override));
 };
 
 class ScreenBufferTest : public ::testing::Test

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -32,13 +32,6 @@
 
 namespace Kilo::editor {
 
-class MockFile : public IO::FileInterface
-{
-public:
-  MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept, override));
-  MOCK_METHOD(std::size_t, read, (int, std::string&), (noexcept, override));
-};
-
 TEST(ScreenBufferTest, IsEmptyWhenCreated)
 {
   ScreenBuffer buffer;
@@ -64,6 +57,13 @@ TEST(ScreenBufferTest, c_strReturnsACStringRepresentationOfTheContentsOfTheBuffe
 
   ASSERT_STREQ(buffer.c_str(), str);
 }
+
+class MockFile : public IO::FileInterface
+{
+public:
+  MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept, override));
+  MOCK_METHOD(std::size_t, read, (int, std::string&), (noexcept, override));
+};
 
 TEST(ScreenBufferTest, flushReturnsTheNumberOfBytesWrittenOnSuccess)
 {

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -105,4 +105,19 @@ TEST(ScreenBufferTest, FlushHandlesEINTR)
   ASSERT_THAT(rv, testing::Eq(23));
 }
 
+TEST(ScreenBufferTest, FlushStopsOnZeroBytesWritten)
+{
+  MockFileInterface mockFile;
+  ScreenBuffer buffer;
+  buffer.write("Buffer that cannot be fully written");
+
+  // Simulate zero bytes written
+  EXPECT_CALL(mockFile, write(STDOUT_FILENO, std::string("Buffer that cannot be fully written")))
+    .WillOnce(testing::Return(0));
+
+  auto rv = buffer.flush(mockFile);
+
+  ASSERT_THAT(rv, testing::Eq(0));
+}
+
 }   // namespace Kilo::editor

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -35,7 +35,7 @@ namespace Kilo::editor {
 class MockFile : public IO::File
 {
 public:
-  MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept));
+  MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept, override));
   MOCK_METHOD(std::size_t, read, (int, std::string&), (noexcept, override));
 };
 

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -39,54 +39,56 @@ public:
   MOCK_METHOD(std::size_t, read, (int, std::string&), (noexcept, override));
 };
 
-class ScreenBufferTest : public ::testing::Test
+TEST(ScreenBufferTest, IsEmptyWhenCreated)
 {
-public:
-  ScreenBuffer buf;
-};
-
-TEST_F(ScreenBufferTest, IsEmptyWhenCreated)
-{
-  ASSERT_EQ(buf.size(), 0);
+  ScreenBuffer buffer;
+  ASSERT_EQ(buffer.size(), 0);
 }
 
-TEST_F(ScreenBufferTest, ItsSizeIncreasesByTheLengthOfTheAppendedString)
+TEST(ScreenBufferTest, ItsSizeIncreasesByTheLengthOfTheAppendedString)
 {
+  ScreenBuffer buffer;
   char const* str = "Hello, World!";
-  buf.write(str, std::strlen(str));
 
-  ASSERT_EQ(buf.size(), 13);
+  buffer.write(str, std::strlen(str));
+
+  ASSERT_EQ(buffer.size(), 13);
 }
 
-TEST_F(ScreenBufferTest, c_strReturnsACStringRepresentationOfTheContentsOfTheBuffer)
+TEST(ScreenBufferTest, c_strReturnsACStringRepresentationOfTheContentsOfTheBuffer)
 {
+  ScreenBuffer buffer;
   char const* str = "The quick brown fox jumped over the lazy dog";
-  buf.write(str, std::strlen(str));
 
-  ASSERT_STREQ(buf.c_str(), str);
+  buffer.write(str, std::strlen(str));
+
+  ASSERT_STREQ(buffer.c_str(), str);
 }
 
-TEST_F(ScreenBufferTest, flushReturnsTheNumberOfBytesWrittenOnSuccess)
+TEST(ScreenBufferTest, flushReturnsTheNumberOfBytesWrittenOnSuccess)
 {
   using namespace ::testing;
 
+  ScreenBuffer buffer;
   MockFile file;
 
   EXPECT_CALL(file, write(_, _)).Times(1).WillOnce(Return(5));
 
-  auto rv = buf.flush(file);
+  auto rv = buffer.flush(file);
 
   ASSERT_THAT(rv, Eq(5));
 }
 
-TEST_F(ScreenBufferTest, flushThrowsAnExceptionOnFailure)
+TEST(ScreenBufferTest, flushThrowsAnExceptionOnFailure)
 {
   using namespace ::testing;
 
+  ScreenBuffer buffer;
   MockFile file;
+
   EXPECT_CALL(file, write(_, _)).Times(1).WillOnce(Throw(std::system_error {}));
 
-  ASSERT_THROW(buf.flush(file), std::system_error);
+  ASSERT_THROW(buffer.flush(file), std::system_error);
 }
 
 }   // namespace Kilo::editor

--- a/tests/ScreenBuffer/ScreenBuffer.test.cpp
+++ b/tests/ScreenBuffer/ScreenBuffer.test.cpp
@@ -32,7 +32,7 @@
 
 namespace Kilo::editor {
 
-class MockFile : public IO::File
+class MockFile : public IO::FileInterface
 {
 public:
   MOCK_METHOD(std::size_t, write, (int, std::string const&), (noexcept, override));

--- a/tests/Termios/Termios.test.cpp
+++ b/tests/Termios/Termios.test.cpp
@@ -28,7 +28,7 @@
 
 namespace Kilo::Terminal {
 
-TEST(getTerminalDriverSettings, Throws_An_Exception_When_Passed_An_Invalid_File_Descriptor)
+TEST(getTerminalDriverSettings, ThrowsAnExceptionWhenPassedAnInvalidFileDescriptor)
 {
   ::termios buf;
   int fd = -STDOUT_FILENO;
@@ -36,7 +36,7 @@ TEST(getTerminalDriverSettings, Throws_An_Exception_When_Passed_An_Invalid_File_
   ASSERT_THROW(getTerminalDriverSettings(fd, buf), std::system_error);
 }
 
-TEST(getTerminalDriverSettings, Runs_Successfully_When_Passed_A_Valid_File_Descriptor)
+TEST(getTerminalDriverSettings, RunsSuccessfullyWhenPassedAValidFileDescriptor)
 {
   ::termios buf;
   int fd = STDIN_FILENO;
@@ -44,7 +44,7 @@ TEST(getTerminalDriverSettings, Runs_Successfully_When_Passed_A_Valid_File_Descr
   ASSERT_NO_THROW(getTerminalDriverSettings(fd, buf));
 }
 
-TEST(ttyRaw, Throws_An_Exception_When_Passed_An_Invalid_File_Descriptor)
+TEST(ttyRaw, ThrowsAnExceptionWhenPassedAnInvalidFileDescriptor)
 {
   ::termios buf;
   ::termios copy;
@@ -54,7 +54,7 @@ TEST(ttyRaw, Throws_An_Exception_When_Passed_An_Invalid_File_Descriptor)
   ASSERT_THROW(ttyRaw(-fd, buf, copy), std::system_error);
 }
 
-TEST(ttyRaw, Succeeds_When_Passed_A_Valid_File_Descriptor)
+TEST(ttyRaw, SucceedsWhenPassedAValidFileDescriptor)
 {
   ::termios buf;
   ::termios copy;
@@ -66,7 +66,7 @@ TEST(ttyRaw, Succeeds_When_Passed_A_Valid_File_Descriptor)
   ASSERT_NO_THROW(ttyRaw(fd, buf, copy));
 }
 
-TEST(ttyReset, Throws_An_Exception_When_Passed_An_Invalid_File_Descriptor)
+TEST(ttyReset, ThrowsAnExceptionWhenPassedAnInvalidFileDescriptor)
 {
   ::termios buf;
   int fd = STDOUT_FILENO;
@@ -76,7 +76,7 @@ TEST(ttyReset, Throws_An_Exception_When_Passed_An_Invalid_File_Descriptor)
   ASSERT_THROW(ttyReset(-fd, buf), std::system_error);
 }
 
-TEST(ttyReset, Succeeds_When_Passed_A_Valid_File_Descriptor)
+TEST(ttyReset, SucceedsWhenPassedAValidFileDescriptor)
 {
   ::termios buf;
   int fd = STDOUT_FILENO;


### PR DESCRIPTION
- **refactor: pass in winsize as a non-const reference to getWindowSize**
- **refactor: move the assignment errno = 0 outside of the if statement**
- **refactor: make methods in classes FileInterface and File noexcept**
- **refactor: delete unused include**
- **test: update method declaration of mocked method**
- **refactor: rewrite method flush write all bytes or throw on failure**
- **docs: update comments of methods File::write and File::read**
- **test: add mock method for method read in class MockFile**
- **test: add override specification to MOCK_METHOD definition of method write**
- **test: remove _ from test case names**
- **refactor: change the input parameter of flush to IO::FileInterface&**
- **test: change the base class of the MockFile class to IO::FileInterface**
- **test: replace ScreenBufferTest test fixtures with regular test suites**
- **test: move the declaration of MockFile just above the test suites that need it**
- **test: rename class MockFile to MockFileInterface**
- **test: pass failing test from ScreenBufferTest test suite**
- **test: delete test case for method c_str from ScreenBufferTest test suite**
- **test: pass failing test from ScreenBufferTest suite**
- **test: verify that method flush handles EINTR errors**
- **fix: check that totalWritten == 0 in postcondition assertion**
- **test: verify the behaviour of flush when there are zero bytes to write**
